### PR TITLE
Add ability to override AsyncListenableTaskExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Besides `Rest`, you can also alternatively inject any of the following types per
 - `AsyncClientHttpRequestFactory`
 - `HttpClient`
 - `ClientHttpMessageConverters`
+- `AsyncListenableTaskExecutor`
 
 A global `AccessTokens` bean is also provided.
 
@@ -220,6 +221,7 @@ The following table shows all beans with their respective name (for the `example
 | `exampleRest`                          | `Rest`                                                             | Base URL                   |
 | `exampleRestTemplate`                  | `RestTemplate`                                                     | Base URL                   |
 | `exampleAsyncRestTemplate`             | `AsyncRestTemplate`                                                | Base URL                   |
+| `exampleAsyncListenableTaskExecutor`   | `AsyncListenableTaskExecutor`                                      | ConcurrentTaskExecutor     |
 
 If you override a bean then all of its dependencies (see the [graph](#customization)), will **not** be registered,
 unless required by some other bean.

--- a/src/test/java/org/zalando/putittorest/AsyncListenableTaskExecutorOverrideTest.java
+++ b/src/test/java/org/zalando/putittorest/AsyncListenableTaskExecutorOverrideTest.java
@@ -1,0 +1,44 @@
+package org.zalando.putittorest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.task.AsyncListenableTaskExecutor;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.zalando.putittorest.Mocks.isMock;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Component
+public class AsyncListenableTaskExecutorOverrideTest {
+    @Configuration
+    @Import(DefaultTestConfiguration.class)
+    public static class TestConfiguration {
+
+        @Bean
+        @Qualifier("example")
+        public AsyncListenableTaskExecutor exampleAsyncListenableTaskExecutor() {
+            return mock(AsyncListenableTaskExecutor.class);
+        }
+
+    }
+
+    @Autowired
+    @Qualifier("example")
+    private AsyncListenableTaskExecutor unit;
+
+    @Test
+    public void shouldOverride() {
+        assertThat(unit, isMock());
+    }
+
+}

--- a/src/test/java/org/zalando/putittorest/AsyncListenableTaskExecutorTest.java
+++ b/src/test/java/org/zalando/putittorest/AsyncListenableTaskExecutorTest.java
@@ -1,0 +1,37 @@
+package org.zalando.putittorest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.task.AsyncListenableTaskExecutor;
+import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Component
+public class AsyncListenableTaskExecutorTest {
+
+    @Configuration
+    @Import(DefaultTestConfiguration.class)
+    public static class TestConfiguration {
+
+    }
+
+    @Autowired
+    @Qualifier("example")
+    private AsyncListenableTaskExecutor unit;
+
+    @Test
+    public void shouldAutowire() {
+        assertThat(unit.getClass(), is(ConcurrentTaskExecutor.class));
+    }
+}


### PR DESCRIPTION
It is useful to override `AsyncListenableTaskExecutor` (to use bounded thread pool for example). In order to do this now, need to override `AsyncHttpRequestFactory` - it requires `HttpClient` instance.