### PR TITLE
Defer loading of the PluginResolver

### DIFF
--- a/src/main/java/org/zalando/putittorest/Plugins.java
+++ b/src/main/java/org/zalando/putittorest/Plugins.java
@@ -3,17 +3,18 @@ package org.zalando.putittorest;
 import org.zalando.riptide.Plugin;
 
 import java.util.List;
+import java.util.function.Supplier;
 
-public final class Plugins {
+final class Plugins {
 
-    private final List<Plugin> plugins;
+    private final Supplier<List<Plugin>> plugins;
 
-    public Plugins(final List<Plugin> plugins) {
+    Plugins(final Supplier<List<Plugin>> plugins) {
         this.plugins = plugins;
     }
 
-    public List<Plugin> getPlugins() {
-        return plugins;
+    List<Plugin> resolvePlugins() {
+        return plugins.get();
     }
 
 }

--- a/src/main/java/org/zalando/putittorest/RestClientAutoConfiguration.java
+++ b/src/main/java/org/zalando/putittorest/RestClientAutoConfiguration.java
@@ -1,6 +1,7 @@
 package org.zalando.putittorest;
 
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureOrder;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -27,7 +28,7 @@ import org.zalando.tracer.spring.TracerAutoConfiguration;
 public class RestClientAutoConfiguration {
 
     @Bean
-    public RestClientPostProcessor restClientPostProcessor(final PluginResolver resolver) {
+    public static RestClientPostProcessor restClientPostProcessor(final ObjectFactory<PluginResolver> resolver) {
         return new RestClientPostProcessor(resolver);
     }
 

--- a/src/main/java/org/zalando/putittorest/RestFactory.java
+++ b/src/main/java/org/zalando/putittorest/RestFactory.java
@@ -15,7 +15,7 @@ final class RestFactory {
                 .requestFactory(requestFactory)
                 .converters(converters)
                 .baseUrl(baseUrl)
-                .plugins(plugins.getPlugins())
+                .plugins(plugins.resolvePlugins())
                 .build();
     }
 

--- a/src/test/java/org/zalando/putittorest/EnforceCoverageTest.java
+++ b/src/test/java/org/zalando/putittorest/EnforceCoverageTest.java
@@ -18,7 +18,7 @@ public final class EnforceCoverageTest {
     private ConfigurableEnvironment environment;
 
     @InjectMocks
-    private RestClientPostProcessor unit = new RestClientPostProcessor(name -> null);
+    private RestClientPostProcessor unit = new RestClientPostProcessor(() -> name -> null);
 
     @Test(expected = IllegalStateException.class)
     public void shouldTriggerSneakyException() {

--- a/src/test/java/org/zalando/putittorest/SpringContextTest.java
+++ b/src/test/java/org/zalando/putittorest/SpringContextTest.java
@@ -1,0 +1,86 @@
+package org.zalando.putittorest;
+
+import com.codahale.metrics.MetricRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.zalando.riptide.Rest;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.genericBeanDefinition;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Component
+public final class SpringContextTest {
+
+    private static final String FACTORY_BEAN_NAME = "MyBean";
+
+    @Configuration
+    @Import({DefaultTestConfiguration.class, BeanImporter.class})
+    public static class TestConfiguration {
+
+
+    }
+
+    public static class BeanImporter implements ImportBeanDefinitionRegistrar {
+
+        @Override
+        public void registerBeanDefinitions(final AnnotationMetadata annotationMetadata, final BeanDefinitionRegistry beanDefinitionRegistry) {
+            final BeanDefinitionBuilder builder = genericBeanDefinition(BeanFactory.class);
+            beanDefinitionRegistry.registerBeanDefinition(FACTORY_BEAN_NAME, builder.getBeanDefinition());
+        }
+    }
+
+    public static class BeanFactory extends AbstractFactoryBean<Object> {
+
+        private final MetricRegistry dependency;
+
+        @Autowired
+        public BeanFactory(final MetricRegistry dependency) {
+            this.dependency = dependency;
+        }
+
+        @Override
+        public Class<?> getObjectType() {
+            return String.class;
+        }
+
+        @Override
+        protected Object createInstance() throws Exception {
+            return dependency;
+        }
+    }
+
+    @Autowired
+    @Qualifier("example")
+    private Rest example;
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void shouldProvideFrameworkBean() throws Exception {
+        assertThat(example, is(notNullValue()));
+    }
+
+    @Test
+    public void shouldProvideFactoryBean() throws Exception {
+        assertThat(context.getBean(FACTORY_BEAN_NAME), is(notNullValue()));
+    }
+
+}


### PR DESCRIPTION
References #64 (we-must-go-deeper-edition).

*RestClientPostProcessor* must not have any direct dependency, otherwise premature bean initialization is still triggered for `FactoryBean`s (see new test case). This pull request shows how to resolve this while keeping the current `Plugins` and `PluginResolver` infrastructure, there might be easier solutions by rethinking this.

What do you think?